### PR TITLE
fix gulp-sass version

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "gulp-jshint": "^1.10.0",
     "gulp-load-plugins": "^0.10.0",
     "gulp-plumber": "^1.0.0",
-    "gulp-sass": "^1.3.3",
+    "gulp-sass": "^2.0.0",
     "gulp-sourcemaps": "^1.5.1",
     "jshint-stylish": "^1.0.1",
     "node-sass": "^2.1.1",


### PR DESCRIPTION
gulp-sassのバージョンが低いとgulpコマンド時にエラーが起こることがあるためバージョンを変更