### PR TITLE
繰り返しフィールドと前方一致するキー名を持つフィールドの入力値が保存されないのを修正

### DIFF
--- a/src/Tarosky/TSCF/UI/Fields/Iterator.php
+++ b/src/Tarosky/TSCF/UI/Fields/Iterator.php
@@ -92,7 +92,7 @@ class Iterator extends Base {
 	 */
 	public function get_field_indexes() {
 		global $wpdb;
-		$key = $this->field['name'] . '_%';
+		$key = $this->field['name'] . '\_%';
 
 		switch ( get_class( $this->object ) ) {
 			case 'WP_Post':
@@ -183,7 +183,7 @@ SQL;
 			  AND {$id_name} = %d
 SQL;
 
-		return $wpdb->query( $wpdb->prepare( $query, "{$this->field['name']}_%", $id ) );
+		return $wpdb->query( $wpdb->prepare( $query, "{$this->field['name']}\_%", $id ) );
 
 	}
 }


### PR DESCRIPTION
下記のような挙動が起きていたので修正してみました。

- [繰り返しフィールドと前方一致するキー名を持つフィールドの入力値が保存されない](https://github.com/ko31/tscf/issues/1) 
