### PR TITLE
「投稿から選択」タイプの表示レイアウト調整（placeholder対応など）

### DIFF
--- a/assets/js/src/tscf-helper.js
+++ b/assets/js/src/tscf-helper.js
@@ -32,7 +32,7 @@
     var postType = $elem.attr('data-post-type');
     var config = {
       minimumInputLength: 1,
-      placeholder       : "", // @see {https://github.com/select2/select2/issues/3497}
+      //placeholder       : "", // @see {https://github.com/select2/select2/issues/3497}
       allowClear        : true,
       ajax              : {
         url           : TSCF.root + '/posts',

--- a/src/Tarosky/TSCF/UI/Fields/PostSelector.php
+++ b/src/Tarosky/TSCF/UI/Fields/PostSelector.php
@@ -31,6 +31,7 @@ class PostSelector extends Input {
 		<input type="hidden" name="<?php echo esc_attr( $this->field['name'] ); ?>" value="<?php echo esc_attr( $this->get_data( false ) ); ?>" />
 		<select class="tscf__input tscf__input--token"
 				data-post-type="<?php echo esc_attr( $this->field['post_type'] ); ?>"
+				data-placeholder="<?php echo esc_attr( $this->field['placeholder'] ); ?>"
 				data-limit="<?php echo esc_attr( $this->field['max'] ); ?>"
 				id="<?php echo esc_attr( $this->field['name'] ); ?>"
 				<?php if ( 1 != $this->field['max'] ) : ?>

--- a/src/Tarosky/TSCF/UI/Fields/PostSelector.php
+++ b/src/Tarosky/TSCF/UI/Fields/PostSelector.php
@@ -36,6 +36,7 @@ class PostSelector extends Input {
 				id="<?php echo esc_attr( $this->field['name'] ); ?>"
 				<?php if ( 1 != $this->field['max'] ) : ?>
 					multiple="multiple"
+					style="width: 99%;"
 				<?php endif; ?>
 		>
 			<?php


### PR DESCRIPTION
## 現象

「投稿から選択」タイプの入力フィールドをブロックエディタで使用すると、
下記のように幅が狭く表示されて入力がしづらい状態になっていました。

- フィールド位置を「ノーマル」「横」いずれの場合も発生
- 単一、複数選択いずれの場合も発生

![sample-before1](https://github.com/user-attachments/assets/ea00228d-16f0-4032-a81b-c936679f18b5)

![sample-before2](https://github.com/user-attachments/assets/1519cc2e-00f5-449a-b1b6-139cce2b8b5c)

この挙動を解消したかったため調整を行ってみました。

## 対応内容

### placeholder の反映

「投稿から選択」タイプで使われている Select2 フィールドに tscf.json で指定した `placeholder` が反映されていなかったため、
`data-placeholder` 属性に値が反映されるよう調整を行いました。

※動作確認時の tscf.json 

```
[
    {
        "name": "post_selector_test",
        "label": "投稿から選択テスト",
        "type": "post",
        "post_types": [
            "post"
        ],
        "context": "normal",
        "priority": "low",
        "description": "",
        "fields": [
            {
                "name": "test_ps_single",
                "label": "投稿から選択（単一）",
                "col": 1,
                "clear": false,
                "required": "",
                "placeholder": "選択してください",
                "description": "",
                "max": "1",
                "type": "post_selector",
                "post_type": "post"
            },
            {
                "name": "test_ps_multi",
                "label": "投稿から選択（複数）",
                "col": 1,
                "clear": false,
                "required": "",
                "placeholder": "選択してください",
                "description": "",
                "max": "",
                "type": "post_selector",
                "post_type": "post"
            }
        ]
    }
]
```

この対応により、単一選択のフィールドは `placeholder` の値に合わせて表示されるようになりました。

![sample-after0](https://github.com/user-attachments/assets/42c2a242-6737-4729-8309-27d0342dc421)

ただし、複数選択のフィールドは表示が変わらない状態です。

![sample-after1](https://github.com/user-attachments/assets/3c6f4a4c-7910-4c6d-ba8a-d818fd41426f)

- 参考：https://select2.org/configuration/data-attributes#camelcase-options

### width の指定

複数選択のフィールドに対しては、`width: 99%` の style を適用して幅が広がるよう調整しました。

![sample-after2](https://github.com/user-attachments/assets/e3ee64e1-2049-450d-ad00-6c0287cb0c0b)

※なお、この調整方法は同様に Select2 ライブラリを使用している CMB2 アドオンプラグイン「[CMB2 Field Type: Select2](https://github.com/mustardBees/cmb-field-select2)」の方式を参考にしています。
https://github.com/mustardBees/cmb-field-select2/blob/master/cmb-field-select2.php#L64

## 動作確認

いずれのフィールドも値の登録など正常に行えることを確認済みです。

![sample-after3](https://github.com/user-attachments/assets/e1500f8d-dce3-4b74-9d67-34755b2e63cd)

