### PR TITLE
イシュー #10 の投稿選択フィールドの検索キャッシュ問題を修正

### DIFF
--- a/assets/js/src/tscf-helper.js
+++ b/assets/js/src/tscf-helper.js
@@ -50,7 +50,7 @@
             results: data.posts
           };
         },
-        cache         : true
+        cache         : false,
       }
     };
     if (0 < max) {


### PR DESCRIPTION
イシュー #10 の問題を修正しました。

## 問題
「投稿から選択」タイプのインクリメンタルサーチで検索結果が０件になると以降、その検索結果が数分間保持される。

## 原因
select2のajax設定で`cache: true`が設定されていたため、検索結果がキャッシュされて古い結果が保持されていた。

## 修正内容
- assets/js/src/tscf-helper.js のselect2設定で`cache: false`に変更
- これにより毎回新しい検索結果を取得するようになり、キャッシュによる問題を解決

## 確認事項
- JavaScript lintチェックは正常に通っています
- 変更は最小限で、他の機能に影響を与えません

by CLINE