### PR TITLE
Introduce release-drafter + release build + watchtower notification

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,36 @@
+name-template: '$RESOLVED_VERSION'
+tag-template: '$RESOLVED_VERSION'
+categories:
+  - title: '🚀 Features'
+    labels:
+      - 'feature'
+      - 'enhancement'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'fix'
+      - 'bugfix'
+      - 'bug'
+  - title: '🧰 Maintenance'
+    labels:
+      - 'chore'
+      - 'dependencies'
+  - title: '📖 Documentation'
+    labels:
+      - 'documentation'
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+  patch:
+    labels:
+      - 'patch'
+  default: patch
+template: |
+  ## Changes
+
+  $CHANGES

--- a/.github/workflows/notify-watchtower.yml
+++ b/.github/workflows/notify-watchtower.yml
@@ -1,0 +1,21 @@
+# 外部パートナーが参加するリポにもそのまま置いてよい（シークレット・鍵はゼロ）。
+#
+# 動作:
+#   release が「リリース（prerelease ではない）」として publish されたら、
+#   tarosky/workflows の reusable workflow を呼び出して watchtower へ通知する。
+
+name: Notify watchtower on release
+
+on:
+  release:
+    types: [released]   # prerelease は除外。両方拾いたければ [released, prereleased] に変更
+
+jobs:
+  notify:
+    permissions:
+      id-token: write   # reusable 側ジョブの id-token: write はここから継承される
+      contents: read
+    uses: tarosky/workflows/.github/workflows/watchtower-notify.yml@main
+    # audience を上書きしたい場合のみ:
+    # with:
+    #   audience: watchtower

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,22 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  update_release_draft:
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,45 @@
+name: Release
+
+on:
+  release:
+    types: [ published ]
+
+permissions:
+  contents: write
+
+jobs:
+
+  release:
+    name: Build & Attach Zip
+    runs-on: ubuntu-latest
+    environment:
+      name: production
+      url: ${{ github.event.release.html_url }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP with composer v2
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 7.4
+          tools: composer
+
+      - name: Install Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Build Plugin
+        run: bash bin/build.sh ${{ github.event.release.tag_name }}
+
+      - name: Zip Archive
+        run: |
+          mkdir ${{ github.event.repository.name }}
+          rsync -av --exclude=${{ github.event.repository.name }} --exclude-from=.distignore ./ ./${{ github.event.repository.name }}/
+          zip -r ./${{ github.event.repository.name }}.zip ./${{ github.event.repository.name }}
+
+      - name: Upload Release Asset
+        run: gh release upload "${{ github.event.release.tag_name }}" "./${{ github.event.repository.name }}.zip"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What
Introduces the release-drafter workflow set (modeled on taro-sitemap):
- `.github/release-drafter.yml` — draft categories & version resolver.
- `.github/workflows/release-drafter.yml` — drafts release notes on push to `master` / PRs.
- `.github/workflows/release.yml` — on `release: published`, builds the plugin (`bin/build.sh`) and attaches the zip (`.distignore`-based).
- `.github/workflows/notify-watchtower.yml` — on `release: released`, notifies watchtower via OIDC (no secrets).

## Notes
- `release.yml` uses PHP 7.4, satisfying this repo's composer `php` constraint (`>=7.4`).
- The `release.yml` build is only exercised at an actual release; verify on the first release.
- No secrets/keys added. Watchtower derives the plugin name server-side from the OIDC `repository` claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)